### PR TITLE
fix: remove spaces while detecting dependency version

### DIFF
--- a/scripts/mavenOutdatedDependecy.sh
+++ b/scripts/mavenOutdatedDependecy.sh
@@ -101,10 +101,10 @@ function get_individual_dependecy() {
     DEPENDENCY=$(grep "$individual_dependency" "$RELATIVE_PATH")
 
     # If dependency is enclosed in single quotes
-    INDIVIDUAL_DEPENDENCY=$(echo "$DEPENDENCY" | sed -n "s/.*'\([^']*\)'.*/\1/p")
+    INDIVIDUAL_DEPENDENCY=$(echo "$DEPENDENCY" | sed -n "s/.*'\([^']*\)'.*/\1/p" | tr -d ' ')
     # If dependency is enclosed in double quotes
     if [ -z "$INDIVIDUAL_DEPENDENCY" ]; then
-        INDIVIDUAL_DEPENDENCY=$(echo "$DEPENDENCY" | sed -n 's/.*"\([^"]*\)".*/\1/p')
+        INDIVIDUAL_DEPENDENCY=$(echo "$DEPENDENCY" | sed -n 's/.*"\([^"]*\)".*/\1/p' | tr -d ' ')
     fi
 
     echo "$INDIVIDUAL_DEPENDENCY"


### PR DESCRIPTION


## Description of the change

> Fixed the issue of space not getting removed in between dynamic version range of any dependency, while creating issues.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
